### PR TITLE
fix(build): bump Dockerfile to Go 1.25 and stop swallowing buildx errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.2 AS builder
+FROM golang:1.25.0 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name search-ruler-builder
 	$(CONTAINER_TOOL) buildx use search-ruler-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	$(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm search-ruler-builder
 	rm Dockerfile.cross
 

--- a/charts/searchruler/Chart.yaml
+++ b/charts/searchruler/Chart.yaml
@@ -6,8 +6,8 @@ type: application
 description: >-
   A Helm chart for SearchRuler, a ruler Engine that allows you 
   to create and manage rules for your search engine.
-version: 0.6.0 # chart version
-appVersion: "0.6.0" # searchruler version
+version: 0.6.1 # chart version
+appVersion: "0.6.1" # searchruler version
 kubeVersion: ">=1.22.0-0" # kubernetes version
 home: https://github.com/freepik-company/searchruler
 sources:


### PR DESCRIPTION
## Summary

The v0.6.0 release built on the runner but never pushed the image — `cluster-control-system` is sitting on `ErrImagePull` because `ghcr.io/freepik-company/searchruler:v0.6.0` does not exist. Two compounding bugs:

1. **`go.mod` requires Go 1.25**, the Dockerfile pins `golang:1.24.2`. `go mod download` failed for every architecture inside `buildx`:
   ```
   go: go.mod requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)
   ```
   The `go` directive was bumped automatically when `prometheus-operator/pkg/apis/monitoring/v1` was added to the module, because `k8s.io/api v0.31.2` (and friends) now require 1.25.

2. **The `docker-buildx` target swallows the error**:
   ```make
   - $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
   ```
   The leading `-` makes Make report `Error 1 (ignored)` and continue. The job exited 0 even though no image was pushed and the workflow showed a green check.

## Changes

- **`Dockerfile`**: bump builder from `golang:1.24.2` to `golang:1.25.0` so `go mod download` matches the module's `go` directive.
- **`Makefile`**: drop the leading `-` on the `buildx build --push` line so any future failure fails the job loudly instead of silently shipping a missing release.
- **`charts/searchruler/Chart.yaml`**: bump `version` and `appVersion` to `0.6.1` so the next release publishes the chart and image together.

After merge, cut release `v0.6.1` to republish the artifact. `cluster-control-system` PR [#728](https://github.com/freepik-company/cluster-control-system/pull/728) will be retargeted from `0.6.0` to `0.6.1`.

## Test plan

- [x] `go build ./...` clean.
- [ ] On merge, create release `v0.6.1` from `main`.
- [ ] Verify `ghcr.io/freepik-company/searchruler:v0.6.1` exists in the GitHub Container Registry after the workflow runs.
- [ ] Verify `searchruler-0.6.1.tgz` lands in the `helm-registry` branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to build/release plumbing (Go builder image version, make target error handling, and Helm chart version bump) with no runtime logic changes.
> 
> **Overview**
> Updates the container build to use Go `1.25.0` so module downloads/builds match the project’s Go version requirements.
> 
> Fixes the `docker-buildx` Make target to stop ignoring `buildx build --push` failures, ensuring CI fails when images aren’t produced. Also bumps the Helm chart `version`/`appVersion` to `0.6.1` to align the next release artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2664de47c8a3ee2f55920838a15f2ab9d9e702d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->