### PR TITLE
fix(metrics): keep customMetric gauges registered while a SearchRule declares them

### DIFF
--- a/charts/searchruler/Chart.yaml
+++ b/charts/searchruler/Chart.yaml
@@ -6,8 +6,8 @@ type: application
 description: >-
   A Helm chart for SearchRuler, a ruler Engine that allows you 
   to create and manage rules for your search engine.
-version: 0.7.0 # chart version
-appVersion: "0.7.0" # searchruler version
+version: 0.7.1 # chart version
+appVersion: "0.7.1" # searchruler version
 kubeVersion: ">=1.22.0-0" # kubernetes version
 home: https://github.com/freepik-company/searchruler
 sources:

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -186,10 +186,19 @@ func updateMetrics(ctx context.Context, rulesPool *pools.RulesStore) error {
 	// orphaned series at the end.
 	seenBasic := map[basicSeriesKey]struct{}{}
 	seenCustom := map[customSeriesKey]struct{}{}
+	// declarersThisTick tracks, for every custom metric, the set of
+	// SearchRule keys (ns/name) that declare it in their spec.
+	// Registration and GC of dynamic gauges hangs off this map: as long
+	// as any rule declares a metric, the gauge stays registered — even
+	// when its bucket list is empty (the typical case for sparse alerts
+	// like WAF blocked-requests, where the buckets only show up during
+	// an actual incident).
+	declarersThisTick := map[string]map[string]struct{}{}
 
 	for _, rule := range rules {
 		ns := rule.SearchRule.Namespace
 		ruleName := rule.SearchRule.Name
+		ruleKey := ns + "/" + ruleName
 
 		// --- legacy gauges -----------------------------------------------
 		if g, ok := defaultRuleMetrics["searchrule_value"]; ok {
@@ -214,6 +223,24 @@ func updateMetrics(ctx context.Context, rulesPool *pools.RulesStore) error {
 				logger.Info(fmt.Sprintf("custom metric on %s/%s rejected: %v", ns, ruleName, err))
 				continue
 			}
+
+			// Register the gauge unconditionally so /metrics keeps
+			// advertising the descriptor (HELP/TYPE) for every metric
+			// declared by a live SearchRule. If no aggregations data is
+			// available yet (the reconciler has not run a first sync, or
+			// the response had no buckets) we skip sample emission but
+			// the gauge stays registered.
+			labelNames := append([]string{"searchrule_namespace", "rule"}, customMetricLabelNames(cm)...)
+			gauge, err := customMgr.gaugeFor(fullName, cm.Help, labelNames)
+			if err != nil {
+				logger.Info(fmt.Sprintf("custom metric %q on %s/%s: %v", fullName, ns, ruleName, err))
+				continue
+			}
+			if declarersThisTick[fullName] == nil {
+				declarersThisTick[fullName] = map[string]struct{}{}
+			}
+			declarersThisTick[fullName][ruleKey] = struct{}{}
+
 			if rule.Aggregations == nil {
 				continue
 			}
@@ -225,12 +252,6 @@ func updateMetrics(ctx context.Context, rulesPool *pools.RulesStore) error {
 			if truncated {
 				customMetricsTruncated.WithLabelValues(ns, ruleName, fullName).Inc()
 			}
-			labelNames := append([]string{"searchrule_namespace", "rule"}, customMetricLabelNames(cm)...)
-			gauge, err := customMgr.gaugeFor(fullName, cm.Help, labelNames)
-			if err != nil {
-				logger.Info(fmt.Sprintf("custom metric %q on %s/%s: %v", fullName, ns, ruleName, err))
-				continue
-			}
 			for _, s := range samples {
 				values := append([]string{ns, ruleName}, s.labelValues...)
 				gauge.WithLabelValues(values...).Set(s.value)
@@ -241,8 +262,8 @@ func updateMetrics(ctx context.Context, rulesPool *pools.RulesStore) error {
 
 	// Drop orphaned basic series.
 	customMgr.pruneBasic(defaultRuleMetrics, seenBasic)
-	// Drop orphaned custom series.
-	customMgr.pruneCustom(seenCustom)
+	// Drop orphaned custom series + GC gauges with no live declarers.
+	customMgr.pruneCustom(seenCustom, declarersThisTick)
 	return nil
 }
 
@@ -367,15 +388,21 @@ type customSeriesKey struct {
 	joined string // \x1f-separated label tuple including ns + rule
 }
 
-// staleGaugeTickThreshold is how many consecutive refreshes a custom gauge
-// can stay empty (no SearchRule emitted samples for it) before the manager
-// unregisters it from the Prometheus registry. With the default
-// --rules-metrics-refresh-rate=10s this means ~5 minutes of inactivity.
-const staleGaugeTickThreshold = 30
-
 // customMetricManager owns dynamic GaugeVecs and the bookkeeping needed to
 // release stale series. It is goroutine-safe: every public method takes the
 // mutex.
+//
+// Lifecycle of a dynamic gauge:
+//   - Registered the first time a SearchRule declares it in
+//     spec.customMetrics (gaugeFor).
+//   - Stays registered as long as any live SearchRule declares it, even
+//     if every refresh tick yields zero samples. This is required for
+//     sparse alerts like Akamai WAF blocked-requests, where buckets only
+//     appear during an incident; otherwise the gauge would be GC'd and
+//     reappear cyclically, breaking PromQL alerts.
+//   - Unregistered (immediately) the first tick where no live rule
+//     declares it — i.e. every SearchRule that referenced it has been
+//     deleted or the customMetric entry was removed from the spec.
 type customMetricManager struct {
 	mu sync.Mutex
 	// gauges maps fullName -> registered GaugeVec.
@@ -384,10 +411,6 @@ type customMetricManager struct {
 	// with. A subsequent rule using the same metric name MUST declare the
 	// same labels in the same order.
 	labels map[string][]string
-	// idleTicks counts how many consecutive ticks we have not emitted any
-	// sample for a registered metric. Reset to 0 on every emission and
-	// once it exceeds staleGaugeTickThreshold the gauge is unregistered.
-	idleTicks map[string]int
 	// previous holds the series we emitted on the last tick keyed by both
 	// metric name and label tuple, so we can DeleteLabelValues the diff.
 	previousBasic  map[basicSeriesKey]struct{}
@@ -398,7 +421,6 @@ func newCustomMetricManager() *customMetricManager {
 	return &customMetricManager{
 		gauges:         map[string]*prometheus.GaugeVec{},
 		labels:         map[string][]string{},
-		idleTicks:      map[string]int{},
 		previousBasic:  map[basicSeriesKey]struct{}{},
 		previousCustom: map[customSeriesKey]struct{}{},
 	}
@@ -417,12 +439,6 @@ func (m *customMetricManager) gaugeFor(fullName, help string, labelNames []strin
 			return nil, fmt.Errorf("metric %q already registered with labels %v; cannot re-register with %v",
 				fullName, m.labels[fullName], labelNames)
 		}
-		// Note: do NOT reset idleTicks here. pruneCustom is the single
-		// authority on idleness — it resets the counter only when the
-		// gauge actually emitted samples this tick. Resetting here would
-		// keep a gauge alive forever even if every bucket fails the
-		// label/value extraction (e.g. a path that never exists), since
-		// updateMetrics calls gaugeFor BEFORE iterating samples.
 		return existing, nil
 	}
 	if help == "" {
@@ -463,11 +479,14 @@ func (m *customMetricManager) pruneBasic(metrics map[string]*prometheus.GaugeVec
 }
 
 // pruneCustom deletes label tuples on dynamically-registered gauges that
-// were absent from this tick. Then it tracks per-gauge idle ticks: a gauge
-// that publishes zero samples for staleGaugeTickThreshold consecutive
-// refreshes is fully unregistered so the /metrics endpoint stops advertising
-// the empty gauge and the registry releases its memory.
-func (m *customMetricManager) pruneCustom(seen map[customSeriesKey]struct{}) {
+// were absent from this tick, then GCs gauges whose set of declaring
+// SearchRules dropped to zero this tick. The previous "30 ticks without
+// samples" heuristic was wrong for sparse metrics: an Akamai WAF rule
+// only exposes buckets during an attack, so a quiet hour would
+// unregister the gauge and PromQL alerts on it would flap or evaluate
+// against nothing. As long as a SearchRule declares the metric in its
+// spec, the gauge stays registered (with zero samples if no buckets).
+func (m *customMetricManager) pruneCustom(seen map[customSeriesKey]struct{}, declarers map[string]map[string]struct{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for prev := range m.previousCustom {
@@ -482,25 +501,16 @@ func (m *customMetricManager) pruneCustom(seen map[customSeriesKey]struct{}) {
 	}
 	m.previousCustom = seen
 
-	// idleTicks tracking: which metrics emitted at least one series this tick?
-	usedThisTick := map[string]struct{}{}
-	for k := range seen {
-		usedThisTick[k.metric] = struct{}{}
-	}
+	// GC: a metric with no live declarer is unregistered immediately.
 	for name := range m.gauges {
-		if _, used := usedThisTick[name]; used {
-			m.idleTicks[name] = 0
+		if decl, ok := declarers[name]; ok && len(decl) > 0 {
 			continue
 		}
-		m.idleTicks[name]++
-		if m.idleTicks[name] >= staleGaugeTickThreshold {
-			if g := m.gauges[name]; g != nil {
-				prometheusRegistry.Unregister(g)
-			}
-			delete(m.gauges, name)
-			delete(m.labels, name)
-			delete(m.idleTicks, name)
+		if g := m.gauges[name]; g != nil {
+			prometheusRegistry.Unregister(g)
 		}
+		delete(m.gauges, name)
+		delete(m.labels, name)
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -321,64 +321,54 @@ func TestCustomMetricManager_GaugeFor_RejectsConflictingLabels(t *testing.T) {
 	}
 }
 
-func TestCustomMetricManager_PruneCustom_GarbageCollectsStale(t *testing.T) {
+func TestCustomMetricManager_PruneCustom_KeepsGaugeWhileDeclared(t *testing.T) {
 	t.Parallel()
+	// A WAF-style sparse metric: the SearchRule declares it but the
+	// underlying query returns zero buckets for many ticks. The gauge
+	// MUST stay registered as long as the SearchRule declares it.
 	m := newCustomMetricManager()
-	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "searchrule_test_gc"}, []string{"searchrule_namespace", "rule", "host"})
-	// Note: we register on the package-level prometheusRegistry because the
-	// manager calls prometheusRegistry.Unregister directly.
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "searchrule_test_sparse"}, []string{"searchrule_namespace", "rule", "host"})
 	if err := prometheusRegistry.Register(g); err != nil {
 		t.Fatalf("register: %v", err)
 	}
 	defer prometheusRegistry.Unregister(g)
-	m.gauges["searchrule_test_gc"] = g
-	m.labels["searchrule_test_gc"] = []string{"searchrule_namespace", "rule", "host"}
+	m.gauges["searchrule_test_sparse"] = g
+	m.labels["searchrule_test_sparse"] = []string{"searchrule_namespace", "rule", "host"}
 
-	// First tick: emit one series so the manager records previousCustom for it.
-	g.WithLabelValues("ns", "rule", "host1").Set(1)
-	seenFirst := map[customSeriesKey]struct{}{
-		{metric: "searchrule_test_gc", joined: "ns\x1frule\x1fhost1"}: {},
+	declared := map[string]map[string]struct{}{
+		"searchrule_test_sparse": {"searchruler/sparse-rule": {}},
 	}
-	m.pruneCustom(seenFirst)
-	if _, ok := m.gauges["searchrule_test_gc"]; !ok {
-		t.Fatalf("gauge should still be registered after first emission")
+	for i := 0; i < 100; i++ {
+		m.pruneCustom(map[customSeriesKey]struct{}{}, declared)
 	}
-
-	// Subsequent empty ticks: simulate staleGaugeTickThreshold ticks with
-	// no samples. After the threshold the gauge must be unregistered.
-	for i := 0; i < staleGaugeTickThreshold; i++ {
-		m.pruneCustom(map[customSeriesKey]struct{}{})
-	}
-	if _, ok := m.gauges["searchrule_test_gc"]; ok {
-		t.Fatalf("gauge should have been GC'd after %d empty ticks", staleGaugeTickThreshold)
+	if _, ok := m.gauges["searchrule_test_sparse"]; !ok {
+		t.Fatalf("gauge should still be registered after 100 empty ticks while a rule declares it")
 	}
 }
 
-func TestCustomMetricManager_PruneCustom_ResetsIdleOnReuse(t *testing.T) {
+func TestCustomMetricManager_PruneCustom_GarbageCollectsWhenNoDeclarer(t *testing.T) {
 	t.Parallel()
 	m := newCustomMetricManager()
-	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "searchrule_test_reuse"}, []string{"searchrule_namespace", "rule", "host"})
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "searchrule_test_gc_decl"}, []string{"searchrule_namespace", "rule", "host"})
 	if err := prometheusRegistry.Register(g); err != nil {
 		t.Fatalf("register: %v", err)
 	}
 	defer prometheusRegistry.Unregister(g)
-	m.gauges["searchrule_test_reuse"] = g
-	m.labels["searchrule_test_reuse"] = []string{"searchrule_namespace", "rule", "host"}
+	m.gauges["searchrule_test_gc_decl"] = g
+	m.labels["searchrule_test_gc_decl"] = []string{"searchrule_namespace", "rule", "host"}
 
-	// Several empty ticks short of the GC threshold.
-	for i := 0; i < staleGaugeTickThreshold-1; i++ {
-		m.pruneCustom(map[customSeriesKey]struct{}{})
+	// First tick: at least one rule declares the metric.
+	declared := map[string]map[string]struct{}{
+		"searchrule_test_gc_decl": {"searchruler/r1": {}},
 	}
-	// One tick with samples must reset the counter.
-	m.pruneCustom(map[customSeriesKey]struct{}{
-		{metric: "searchrule_test_reuse", joined: "ns\x1frule\x1fh"}: {},
-	})
-	// Another full streak of empty ticks; the gauge must survive because the
-	// reset happened mid-streak.
-	for i := 0; i < staleGaugeTickThreshold-1; i++ {
-		m.pruneCustom(map[customSeriesKey]struct{}{})
+	m.pruneCustom(map[customSeriesKey]struct{}{}, declared)
+	if _, ok := m.gauges["searchrule_test_gc_decl"]; !ok {
+		t.Fatalf("gauge should be registered while declared")
 	}
-	if _, ok := m.gauges["searchrule_test_reuse"]; !ok {
-		t.Fatalf("gauge should still be registered; idle counter reset failed")
+
+	// SearchRule is deleted from the cluster: declarers becomes empty.
+	m.pruneCustom(map[customSeriesKey]struct{}{}, map[string]map[string]struct{}{})
+	if _, ok := m.gauges["searchrule_test_gc_decl"]; ok {
+		t.Fatalf("gauge should have been GC'd the very first tick after the last declarer disappeared")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a real bug found in production today: the new `customMetrics` gauges register and unregister cyclically when the underlying query goes through quiet periods. Concrete case from CR cluster:

```
$ curl /metrics | grep '^searchrule_akamai_'
searchrule_akamai_5xx_by_host{...} 0.02
searchrule_akamai_statuscode_by_host{...} 0.0
# searchrule_akamai_waf_blocked_by_host  ← MISSING
```

The WAF SearchRule is healthy (`State=Normal`, `PrometheusRule.Synced`, `customMetrics` set in spec), but `searchrule_akamai_waf_blocked_by_host` is absent because the operator GC'd the gauge: WAF only emits buckets during an actual attack, so 30+ ticks pass with no samples and `staleGaugeTickThreshold` triggers an Unregister.

That heuristic was wrong for sparse alerts. The whole point of the gauge is to *light up* when buckets appear; if the gauge has been unregistered seconds before, PromQL evaluates against nothing and the alert flaps for an entire scrape interval before recovering.

## Fix

GC is now declarer-based, not idle-time-based:

- `updateMetrics` records the SearchRules that **declare** each metric in their spec, regardless of whether their last response had buckets.
- `pruneCustom` unregisters only gauges whose declarer set is empty (every rule that referenced them has been deleted or its `customMetrics` entry removed).
- `gaugeFor` is now called unconditionally for every declared metric, so `/metrics` advertises the descriptor (HELP/TYPE) from the very first reconcile — no waiting for the first non-empty response to materialise the gauge.

Net effect: a WAF SearchRule keeps `searchrule_akamai_waf_blocked_by_host` registered with zero samples during quiet periods. PromQL `searchrule_akamai_waf_blocked_by_host > 0` returns "no data" cleanly instead of "missing series" and starts firing the moment a bucket appears.

## Tests

- `TestCustomMetricManager_PruneCustom_KeepsGaugeWhileDeclared`: 100 empty ticks while a declarer exists → gauge stays.
- `TestCustomMetricManager_PruneCustom_GarbageCollectsWhenNoDeclarer`: declarer disappears → gauge unregistered the very next tick.
- Removed the previous tick-counting tests, which validated behaviour we no longer want.

`go test -race ./internal/...` passes.

## Versioning

Chart and appVersion bumped to `0.7.1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lifecycle/GC rules for dynamic Prometheus gauges; mistakes could leak metrics or remove expected series, impacting alerting/observability but not core data paths.
> 
> **Overview**
> Fixes custom metric gauge flapping by switching dynamic gauge GC from *idle-tick based* to *declarer based*. `updateMetrics` now registers a gauge for every metric declared in `spec.customMetrics` (even with no buckets) and tracks which SearchRules declare each metric, and `pruneCustom` only unregisters gauges when no live rule declares them.
> 
> Updates unit tests to cover “keep gauge while declared” and “GC immediately when last declarer disappears”, and bumps Helm chart `version`/`appVersion` to `0.7.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ed0ae7b89f21632da1955e98497ae554b63135c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->